### PR TITLE
Make it work with rustc 1.0.0-nightly

### DIFF
--- a/src/cipher/ecdhe.rs
+++ b/src/cipher/ecdhe.rs
@@ -1,5 +1,5 @@
 use std::rand::{Rng, OsRng};
-use std::io::BufReader;
+use std::old_io::BufReader;
 
 use tls_result::TlsResult;
 use tls_result::TlsErrorKind::IllegalParameter;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
-use std::io::net::tcp::TcpStream;
+use std::old_io::net::tcp::TcpStream;
 use std::slice::bytes::copy_memory;
 use std::cmp;
-use std::io::{IoResult, IoError, OtherIoError};
+use std::old_io::{IoResult, IoError, OtherIoError};
 use std::rand::{Rng, OsRng};
 
 use tls_result::TlsResult;
@@ -253,6 +253,10 @@ impl<R: Reader, W: Writer> Writer for TlsClient<R, W> {
             }
         }
     }
+
+	fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
+		return self.write(buf);
+	}
 }
 
 impl<R: Reader, W: Writer> Reader for TlsClient<R, W> {

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,4 +1,4 @@
-use std::io::MemReader;
+use std::old_io::MemReader;
 
 use tls::TLS_VERSION;
 use tls_result::TlsResult;
@@ -340,7 +340,7 @@ impl Handshake {
 
 #[cfg(test)]
 mod test {
-    use std::io::MemReader;
+    use std::old_io::MemReader;
     use tls_item::TlsItem;
     use cipher::CipherSuite;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use std::io::{MemReader, ByRefReader, ByRefWriter};
+use std::old_io::{MemReader, ByRefReader, ByRefWriter};
 use std::rand::OsRng;
 use std::iter::repeat;
 

--- a/src/tls_item.rs
+++ b/src/tls_item.rs
@@ -383,7 +383,7 @@ macro_rules! tls_option {
                             return Ok(None);
                         }
 
-                        let mut rest_reader = ::std::io::MemReader::new(rest);
+                        let mut rest_reader = ::std::old_io::MemReader::new(rest);
                         let extensions: $t = try!(TlsItem::tls_read(&mut rest_reader));
                         Ok(Some(extensions))
                     }

--- a/src/tls_result.rs
+++ b/src/tls_result.rs
@@ -1,5 +1,6 @@
 use std::error::{Error, FromError};
-use std::io::IoError;
+use std::old_io::IoError;
+use std::fmt;
 
 #[derive(Copy, PartialEq, Show)]
 pub enum TlsErrorKind {
@@ -51,10 +52,12 @@ impl Error for TlsError {
             TlsErrorKind::AlertReceived => "received an alert",
         }
     }
+}
 
-    fn detail(&self) -> Option<String> {
-        Some(self.desc.clone())
-    }
+impl fmt::String for TlsError {
+	fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		return formatter.write_str(self.description());
+	}
 }
 
 impl FromError<IoError> for TlsError {


### PR DESCRIPTION
at rustc 1.0.0-nightly (c5961ad06 2015-01-28 21:49:38 +0000)

Renamed `std::io` to `std::old_io` since `io` is moving somewhere.
Added a couple of missing new trait requirements.

`cargo test` is still failing:

```
src/crypto/p256.rs:615:26: 615:32 error: type `[u32]` does not implement any method in scope named `fmt`
src/crypto/p256.rs:615                 self.v[].fmt(a)
                                                ^~~~~~
src/crypto/p256.rs:615:32: 615:32 help: methods from traits can only be called if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
src/crypto/p256.rs:615:32: 615:32 help: candidate #1: use `core::fmt::Debug`
src/crypto/poly1305.rs:348:24: 348:30 error: type `[u32]` does not implement any method in scope named `fmt`
src/crypto/poly1305.rs:348             (self.v[]).fmt(a)
                                                  ^~~~~~
src/crypto/poly1305.rs:348:30: 348:30 help: methods from traits can only be called if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
src/crypto/poly1305.rs:348:30: 348:30 help: candidate #1: use `core::fmt::Debug`
```