### PR TITLE
Update for upstream changes

### DIFF
--- a/examples/google.rs
+++ b/examples/google.rs
@@ -1,11 +1,5 @@
-suruga is Rust implementation of [TLS 1.2][tls-12].
+#![feature(net)]
 
-It currently implements some core parts of TLS 1.2,
-NIST P-256 [ECDHE][tls-ecc] and [chacha20-poly1305][tls-chacha20-poly1305].
-
-# Usage
-
-```Rust
 extern crate suruga;
 
 use std::io::prelude::*;
@@ -29,8 +23,3 @@ fn test() -> suruga::tls_result::TlsResult<()> {
 
     Ok(())
 }
-```
-
-[tls-12]: http://tools.ietf.org/html/rfc5246
-[tls-ecc]: http://tools.ietf.org/html/rfc4492
-[tls-chacha20-poly1305]: https://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -1,3 +1,4 @@
+use util::{ReadExt, WriteExt};
 use tls_result::{TlsResult, TlsError, TlsErrorKind};
 use tls_item::TlsItem;
 

--- a/src/cipher/chacha20_poly1305.rs
+++ b/src/cipher/chacha20_poly1305.rs
@@ -23,7 +23,7 @@ fn compute_mac(poly_key: &[u8], encrypted: &[u8], ad: &[u8]) -> [u8; MAC_LEN] {
     // note that in draft-agl-tls-chacha20poly1305-01 length is first
     fn push_all_with_len(vec: &mut Vec<u8>, data: &[u8]) {
         vec.push_all(data);
-        vec.push_all(&u64_le_array(data.len() as u64)[]);
+        vec.push_all(&u64_le_array(data.len() as u64));
     }
 
     push_all_with_len(&mut msg, ad);
@@ -38,7 +38,7 @@ fn compute_mac(poly_key: &[u8], encrypted: &[u8], ad: &[u8]) -> [u8; MAC_LEN] {
         k[i] = poly_key[MAC_LEN + i];
     }
 
-    poly1305::authenticate(&msg[], &r, &k)
+    poly1305::authenticate(&msg, &r, &k)
 }
 
 struct ChaCha20Poly1305Encryptor {
@@ -47,12 +47,12 @@ struct ChaCha20Poly1305Encryptor {
 
 impl Encryptor for ChaCha20Poly1305Encryptor {
     fn encrypt(&mut self, nonce: &[u8], data: &[u8], ad: &[u8]) -> Vec<u8> {
-        let mut chacha20 = ChaCha20::new(&self.key[], nonce);
+        let mut chacha20 = ChaCha20::new(&self.key, nonce);
         let poly1305_key = chacha20.next();
 
         let mut encrypted = chacha20.encrypt(data);
-        let mac = compute_mac(&poly1305_key[], &encrypted[], ad);
-        encrypted.push_all(&mac[]);
+        let mac = compute_mac(&poly1305_key, &encrypted, ad);
+        encrypted.push_all(&mac);
 
         encrypted
     }
@@ -72,10 +72,10 @@ impl Decryptor for ChaCha20Poly1305Decryptor {
         let encrypted = &data[..(enc_len - MAC_LEN)];
         let mac_expected = &data[(enc_len - MAC_LEN)..];
 
-        let mut chacha20 = ChaCha20::new(&self.key[], nonce);
+        let mut chacha20 = ChaCha20::new(&self.key, nonce);
         let poly1305_key = chacha20.next();
 
-        let mac_computed = compute_mac(&poly1305_key[], &encrypted[], ad);
+        let mac_computed = compute_mac(&poly1305_key, &encrypted, ad);
 
         // SECRET
         // even if `mac_computed != mac_expected`, decrypt the data to prevent timing attack.

--- a/src/cipher/chacha20_poly1305.rs
+++ b/src/cipher/chacha20_poly1305.rs
@@ -30,11 +30,11 @@ fn compute_mac(poly_key: &[u8], encrypted: &[u8], ad: &[u8]) -> [u8; MAC_LEN] {
     push_all_with_len(&mut msg, encrypted);
 
     let mut r = [0u8; MAC_LEN];
-    for i in (0us..MAC_LEN) {
+    for i in (0..MAC_LEN) {
         r[i] = poly_key[i];
     }
     let mut k = [0u8; MAC_LEN];
-    for i in (0us..MAC_LEN) {
+    for i in (0..MAC_LEN) {
         k[i] = poly_key[MAC_LEN + i];
     }
 
@@ -82,7 +82,7 @@ impl Decryptor for ChaCha20Poly1305Decryptor {
         let plain = chacha20.encrypt(encrypted);
 
         let mut diff = 0u8;
-        for i in (0us..MAC_LEN) {
+        for i in (0..MAC_LEN) {
             diff |= mac_computed[i] ^ mac_expected[i];
         }
 

--- a/src/cipher/ecdhe.rs
+++ b/src/cipher/ecdhe.rs
@@ -51,7 +51,7 @@ impl KeyExchange for EllipticDiffieHellman {
         fn get_random_x(rng: &mut OsRng) -> p256::int256::Int256 {
             loop {
                 let mut x = p256::int256::ZERO;
-                for i in 0us..8 {
+                for i in 0..8 {
                     x.v[i] = rng.next_u32();
                 }
                 let xx = x.reduce_once(0);

--- a/src/cipher/ecdhe.rs
+++ b/src/cipher/ecdhe.rs
@@ -1,7 +1,8 @@
+use std::io::Cursor;
 use rand::{Rng, OsRng};
-use std::old_io::BufReader;
 
 use crypto::wrapping::Wrapping as W;
+use util::{ReadExt, WriteExt};
 use tls_result::TlsResult;
 use tls_result::TlsErrorKind::IllegalParameter;
 use tls_item::TlsItem;
@@ -36,7 +37,7 @@ pub struct EllipticDiffieHellman;
 
 impl KeyExchange for EllipticDiffieHellman {
     fn compute_keys(&self, data: &[u8], rng: &mut OsRng) -> TlsResult<(Vec<u8>, Vec<u8>)> {
-        let mut reader = BufReader::new(data);
+        let mut reader = Cursor::new(data);
         let ecdh_params: EcdheServerKeyExchange = try!(TlsItem::tls_read(&mut reader));
 
         let gy = &ecdh_params.params.public;

--- a/src/cipher/ecdhe.rs
+++ b/src/cipher/ecdhe.rs
@@ -1,6 +1,7 @@
 use rand::{Rng, OsRng};
 use std::old_io::BufReader;
 
+use crypto::wrapping::Wrapping as W;
 use tls_result::TlsResult;
 use tls_result::TlsErrorKind::IllegalParameter;
 use tls_item::TlsItem;
@@ -52,11 +53,11 @@ impl KeyExchange for EllipticDiffieHellman {
             loop {
                 let mut x = p256::int256::ZERO;
                 for i in 0..8 {
-                    x.v[i] = rng.next_u32();
+                    x.v[i] = W(rng.next_u32());
                 }
-                let xx = x.reduce_once(0);
+                let xx = x.reduce_once(W(0));
                 let x_is_okay = xx.compare(&x);
-                if x_is_okay == 0 {
+                if x_is_okay == W(0) {
                     return x;
                 }
             }

--- a/src/cipher/ecdhe.rs
+++ b/src/cipher/ecdhe.rs
@@ -38,7 +38,7 @@ impl KeyExchange for EllipticDiffieHellman {
         let mut reader = BufReader::new(data);
         let ecdh_params: EcdheServerKeyExchange = try!(TlsItem::tls_read(&mut reader));
 
-        let gy = &*ecdh_params.params.public;
+        let gy = &ecdh_params.params.public;
         let gy = p256::NPoint256::from_uncompressed_bytes(gy);
         let gy = match gy {
             None => {

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -52,7 +52,7 @@ macro_rules! cipher_suite {
             pub fn new_aead(&self) -> Box<Aead> {
                 match *self {
                     $(
-                        CipherSuite::$id => box $cipher as Box<Aead>,
+                        CipherSuite::$id => Box::new($cipher) as Box<Aead>,
                     )+
                     CipherSuite::UnknownCipherSuite => unreachable!(),
                 }
@@ -61,7 +61,7 @@ macro_rules! cipher_suite {
             pub fn new_kex(&self) -> Box<KeyExchange> {
                 match *self {
                     $(
-                        CipherSuite::$id => box $kex as Box<KeyExchange>,
+                        CipherSuite::$id => Box::new($kex) as Box<KeyExchange>,
                     )+
                     CipherSuite::UnknownCipherSuite => unreachable!(),
                 }

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -1,5 +1,6 @@
 use rand::OsRng;
 
+use util::{ReadExt, WriteExt};
 use tls_result::TlsResult;
 use tls_result::TlsErrorKind::UnexpectedMessage;
 use tls_item::TlsItem;
@@ -72,7 +73,7 @@ macro_rules! cipher_suite {
         }
 
         impl TlsItem for CipherSuite {
-            fn tls_write<W: Writer>(&self, writer: &mut W) -> TlsResult<()> {
+            fn tls_write<W: WriteExt>(&self, writer: &mut W) -> TlsResult<()> {
                 $(
                     if *self == CipherSuite::$id {
                         try!(writer.write_u8($v1));
@@ -84,7 +85,7 @@ macro_rules! cipher_suite {
                 return tls_err!(UnexpectedMessage, "unexpected CipherSuite: {:?}", self);
             }
 
-            fn tls_read<R: Reader>(reader: &mut R) -> TlsResult<CipherSuite> {
+            fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<CipherSuite> {
                 let id1 = try!(reader.read_u8());
                 let id2 = try!(reader.read_u8());
                 $(

--- a/src/cipher/prf.rs
+++ b/src/cipher/prf.rs
@@ -15,7 +15,7 @@ pub fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
 
     let mut i_msg = [0x36u8; B].to_vec();
     let mut o_msg = [0x5cu8; B].to_vec();
-    for i in (0us..key.len()) {
+    for i in (0..key.len()) {
         i_msg[i] ^= key[i];
         o_msg[i] ^= key[i];
     }
@@ -137,7 +137,7 @@ mod test {
         let ret1 = {
             let mut prf = Prf::new(Vec::new(), Vec::new());
             let mut ret = Vec::new();
-            for _ in 0us..100 {
+            for _ in 0..100 {
                 ret.push_all(&prf.get_bytes(1));
             }
             ret

--- a/src/cipher/prf.rs
+++ b/src/cipher/prf.rs
@@ -21,9 +21,9 @@ pub fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
     }
 
     i_msg.push_all(msg);
-    let h_i = sha256(&i_msg[]);
-    o_msg.push_all(&h_i[]);
-    let h_o = sha256(&o_msg[]);
+    let h_i = sha256(&i_msg);
+    o_msg.push_all(&h_i);
+    let h_o = sha256(&o_msg);
 
     h_o
 }
@@ -37,7 +37,7 @@ pub struct Prf {
 
 impl Prf {
     pub fn new(secret: Vec<u8>, seed: Vec<u8>) -> Prf {
-        let a1 = hmac_sha256(&secret[], &seed[]);
+        let a1 = hmac_sha256(&secret, &seed);
 
         Prf {
             secret: secret,
@@ -50,9 +50,9 @@ impl Prf {
     // get 32-byte pseudorandom number.
     fn next_block(&mut self) -> [u8; 32] {
         let mut input = self.a.to_vec();
-        input.push_all(&self.seed[]);
-        let next = hmac_sha256(&self.secret[], &input[]);
-        self.a = hmac_sha256(&self.secret[], &self.a[]);
+        input.push_all(&self.seed);
+        let next = hmac_sha256(&self.secret, &input);
+        self.a = hmac_sha256(&self.secret, &self.a);
 
         next
     }
@@ -78,7 +78,7 @@ impl Prf {
             let next_block = self.next_block();
             let slice_len = size - ret.len();
             if slice_len > 32 {
-                ret.push_all(&next_block[]);
+                ret.push_all(&next_block);
             } else {
                 ret.push_all(&next_block[..slice_len]);
                 self.buf = next_block[slice_len..].to_vec();
@@ -128,7 +128,7 @@ mod test {
 
         for &(key, input, expected) in VALUES.iter() {
             let actual = hmac_sha256(key, input);
-            assert_eq!(&actual[], expected);
+            assert_eq!(&actual, expected);
         }
     }
 
@@ -138,7 +138,7 @@ mod test {
             let mut prf = Prf::new(Vec::new(), Vec::new());
             let mut ret = Vec::new();
             for _ in 0us..100 {
-                ret.push_all(&prf.get_bytes(1)[]);
+                ret.push_all(&prf.get_bytes(1));
             }
             ret
         };
@@ -153,8 +153,8 @@ mod test {
         let ret3 = {
             let mut prf = Prf::new(Vec::new(), Vec::new());
             let mut b = prf.get_bytes(33);
-            b.push_all(&prf.get_bytes(33)[]);
-            b.push_all(&prf.get_bytes(100 - 33 * 2)[]);
+            b.push_all(&prf.get_bytes(33));
+            b.push_all(&prf.get_bytes(100 - 33 * 2));
             b
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,13 +166,13 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
         // can be broken into several records. This leads to alert attack.
         // since we don't accept strange alerts, all "normal" alert messages are
         // treated as error, so now we can assert that we haven't received alerts.
-        let verify_hash = sha256(&msgs[]);
+        let verify_hash = sha256(&msgs);
 
         let client_verify_data = {
             let finished_label = b"client finished";
 
             let mut label_seed = finished_label.to_vec();
-            label_seed.push_all(&verify_hash[]);
+            label_seed.push_all(&verify_hash);
             let mut prf = Prf::new(master_secret.clone(), label_seed);
             prf.get_bytes(cipher_suite.verify_data_len())
         };
@@ -192,10 +192,10 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
                 // ideally we may save "raw" packet data..
                 let mut serv_msgs = Vec::new();
                 // FIXME: this should not throw "io error".. should throw "internal error"
-                try!(serv_msgs.write_all(&msgs[]));
+                try!(serv_msgs.write_all(&msgs));
                 try!(finished.tls_write(&mut serv_msgs));
 
-                let verify_hash = sha256(&serv_msgs[]);
+                let verify_hash = sha256(&serv_msgs);
                 verify_hash
             };
 
@@ -203,13 +203,13 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
                 let finished_label = b"server finished";
 
                 let mut label_seed = finished_label.to_vec();
-                label_seed.push_all(&verify_hash[]);
+                label_seed.push_all(&verify_hash);
                 let mut prf = Prf::new(master_secret, label_seed);
                 prf.get_bytes(cipher_suite.verify_data_len())
             };
 
-            let verify_ok = crypto_compare(&server_finished[],
-                                           &server_verify_data[]);
+            let verify_ok = crypto_compare(&server_finished,
+                                           &server_verify_data);
             if !verify_ok {
                 return tls_err!(DecryptError, "server sent wrong verify data");
             }
@@ -269,7 +269,7 @@ impl<R: Reader, W: Writer> Reader for TlsClient<R, W> {
                         break; // FIXME: stop if EOF. otherwise raise error?
                     }
                 };
-                self.buf.push_all(&data[]);
+                self.buf.push_all(&data);
             }
 
             let selflen = self.buf.len();

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,7 +101,7 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
         // we always use server key exchange
         let server_key_ex_data = expect!(server_key_exchange);
         let kex = cipher_suite.new_kex();
-        let (key_data, pre_master_secret) = try!(kex.compute_keys(&*server_key_ex_data,
+        let (key_data, pre_master_secret) = try!(kex.compute_keys(&server_key_ex_data,
                                                                   &mut self.tls.rng));
 
         expect!(server_hello_done);
@@ -114,8 +114,8 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
         // SECRET
         let master_secret = {
             let mut label_seed = b"master secret".to_vec();
-            label_seed.push_all(&*cli_random);
-            label_seed.push_all(&*server_hello_data.random);
+            label_seed.push_all(&cli_random);
+            label_seed.push_all(&server_hello_data.random);
 
             let mut prf = Prf::new(pre_master_secret, label_seed);
             prf.get_bytes(48)
@@ -126,8 +126,8 @@ impl<R: Reader, W: Writer> TlsClient<R, W> {
         // SECRET
         let read_key = {
             let mut label_seed = b"key expansion".to_vec();
-            label_seed.push_all(&*server_hello_data.random);
-            label_seed.push_all(&*cli_random);
+            label_seed.push_all(&server_hello_data.random);
+            label_seed.push_all(&cli_random);
 
             let mut prf = Prf::new(master_secret.clone(), label_seed);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -258,7 +258,7 @@ impl<R: Reader, W: Writer> Writer for TlsClient<R, W> {
 impl<R: Reader, W: Writer> Reader for TlsClient<R, W> {
     // if ssl connection is failed, return `EndOfFile`.
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        let mut pos = 0us;
+        let mut pos: usize = 0;
         let len = buf.len();
         while pos < len {
             let remaining = len - pos;

--- a/src/crypto/chacha20.rs
+++ b/src/crypto/chacha20.rs
@@ -160,8 +160,8 @@ mod test {
     fn check_keystream(key: &[u8], nonce: &[u8], keystream: &[u8]) {
         let mut chacha = ChaCha20::new(key, nonce);
         let input: Vec<_> = repeat(0u8).take(keystream.len()).collect();
-        let output = chacha.encrypt(&input[]);
-        assert_eq!(&output[], keystream);
+        let output = chacha.encrypt(&input);
+        assert_eq!(&output[..], keystream);
     }
 
     #[test]

--- a/src/crypto/chacha20.rs
+++ b/src/crypto/chacha20.rs
@@ -32,7 +32,7 @@ impl ChaCha20 {
         vals[2] = 0x79622d32;
         vals[3] = 0x6b206574;
 
-        for i in (0us..8) {
+        for i in (0..8) {
             vals[4 + i] = to_le_u32!(key[4 * i]);
         }
 
@@ -85,7 +85,7 @@ impl ChaCha20 {
         }
 
         let mut vals = self.vals;
-        for _ in (0us..10) {
+        for _ in (0..10) {
             // column round
             quarter_round_idx!(vals, 0, 4, 8, 12);
             quarter_round_idx!(vals, 1, 5, 9, 13);
@@ -99,7 +99,7 @@ impl ChaCha20 {
             quarter_round_idx!(vals, 3, 4, 9, 14);
         }
 
-        for i in (0us..16) {
+        for i in (0..16) {
             vals[i] += self.vals[i];
         }
 
@@ -120,7 +120,7 @@ impl ChaCha20 {
 
         let next_bytes = {
             let mut next_bytes = [0u8; 64];
-            for i in (0us..16) {
+            for i in (0..16) {
                 next_bytes[4 * i + 0] = next[i] as u8;
                 next_bytes[4 * i + 1] = (next[i] >> 8) as u8;
                 next_bytes[4 * i + 2] = (next[i] >> 16) as u8;
@@ -200,10 +200,10 @@ mod test {
                           \x5d\xdc\x49\x7a\x0b\x46\x6e\x7d\x6b\xbd\xb0\x04\x1b\x2f\x58\x6b";
         check_keystream(&key, &nonce, keystream);
 
-        for i in (0us..0x20) {
+        for i in (0..0x20) {
             key[i] = i as u8;
         }
-        for i in (0us..0x08) {
+        for i in (0..0x08) {
             nonce[i] = i as u8;
         }
         let keystream = b"\xf7\x98\xa1\x89\xf1\x95\xe6\x69\x82\x10\x5f\xfb\x64\x0b\xb7\x75\

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,8 @@
+// basic crypto primitives
+
+pub mod wrapping;
+
+pub mod sha2;
+pub mod p256;
+pub mod poly1305;
+pub mod chacha20;

--- a/src/crypto/p256.rs
+++ b/src/crypto/p256.rs
@@ -189,8 +189,8 @@ impl Point256 {
 
     pub fn mult_scalar(&self, n: &Int256) -> Point256 {
         let mut ret = INFTY.clone();
-        for i in (0us..7).rev() {
-            for j in (0us..8).rev() {
+        for i in (0..7).rev() {
+            for j in (0..8).rev() {
                 let bit = (n.v[i] >> j) & 1;
 
                 let ret2 = ret.double();
@@ -297,7 +297,7 @@ pub mod int256 {
         // otherwise return 1.
         pub fn compare(&self, b: &Int256) -> u32 {
             let mut diff = 0u32;
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 diff |= self.v[i] ^ b.v[i];
             }
             diff |= diff >> 16;
@@ -312,7 +312,7 @@ pub mod int256 {
         // if flag == 1, returns b
         pub fn choose(flag: u32, a: &Int256, b: &Int256) -> Int256 {
             let mut v = [0; LIMBS];
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 v[i] = a.v[i] ^ (flag * (a.v[i] ^ b.v[i]));
             }
             Int256 { v: v }
@@ -327,7 +327,7 @@ pub mod int256 {
 
             // invariant: carry <= 1
             let mut carry = 0u64;
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 // add <= 2^33
                 let add = (self.v[i] as u64) + (b.v[i] as u64) + carry;
                 v.v[i] = add as u32;
@@ -345,7 +345,7 @@ pub mod int256 {
 
             // invariant: carry_sub <= 1
             let mut carry_sub = 0u64;
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 // -2^32 <= sub <= 2^32
                 let sub = (self.v[i] as u64) - (b.v[i] as u64) - carry_sub;
                 // if sub < 0, set carry_sub = 1 and sub += 2^32
@@ -387,8 +387,8 @@ pub mod int256 {
 
         pub fn mult(&self, b: &Int256) -> Int256 {
             let mut w = [0u64; LIMBS * 2];
-            for i in (0us..LIMBS) {
-                for j in (0us..LIMBS) {
+            for i in (0..LIMBS) {
+                for j in (0..LIMBS) {
                     let ij = i + j;
                     let v_ij = (self.v[i] as u64) * (b.v[j] as u64);
                     let v_ij_low = (v_ij as u32) as u64;
@@ -403,7 +403,7 @@ pub mod int256 {
 
             let mut v = [0u32; LIMBS * 2];
             let mut carry = 0u64;
-            for i in 0us..(LIMBS * 2) {
+            for i in 0..(LIMBS * 2) {
                 let a = w[i] + carry;
                 v[i] = a as u32;
                 carry = a >> 32;
@@ -411,25 +411,25 @@ pub mod int256 {
             debug_assert_eq!(carry, 0);
 
             let mut buf = ZERO;
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 buf.v[i] = v[i];
             }
             let t = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..5) {
+            for i in (0..5) {
                 buf.v[i + 3] = v[i + 11];
             }
             let s1 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..4) {
+            for i in (0..4) {
                 buf.v[i + 3] = v[i + 12];
             }
             let s2 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..3) {
+            for i in (0..3) {
                 buf.v[i] = v[i + 8];
             }
             buf.v[6] = v[14];
@@ -437,7 +437,7 @@ pub mod int256 {
             let s3 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..3) {
+            for i in (0..3) {
                 buf.v[i] = v[i + 9];
                 buf.v[i + 3] = v[i + 13];
             }
@@ -446,7 +446,7 @@ pub mod int256 {
             let s4 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..3) {
+            for i in (0..3) {
                 buf.v[i] = v[i + 11];
             }
             buf.v[6] = v[8];
@@ -454,7 +454,7 @@ pub mod int256 {
             let d1 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..4) {
+            for i in (0..4) {
                 buf.v[i] = v[i + 12];
             }
             buf.v[6] = v[9];
@@ -462,7 +462,7 @@ pub mod int256 {
             let d2 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..3) {
+            for i in (0..3) {
                 buf.v[i] = v[i + 13];
                 buf.v[i + 3] = v[i + 8];
             }
@@ -470,7 +470,7 @@ pub mod int256 {
             let d3 = buf.reduce_once(0);
 
             let mut buf = ZERO;
-            for i in (0us..3) {
+            for i in (0..3) {
                 buf.v[i + 3] = v[i + 9];
             }
             buf.v[7] = v[13];
@@ -552,14 +552,14 @@ pub mod int256 {
             let is_odd = self.v[0] & 1;
 
             let mut half_even = ZERO;
-            for i in 0us..(LIMBS - 1) {
+            for i in 0..(LIMBS - 1) {
                 half_even.v[i] = (self.v[i] >> 1) | ((self.v[i + 1] & 1) << 31);
             }
             half_even.v[LIMBS - 1] = self.v[LIMBS - 1] >> 1;
 
             let mut half_odd = ZERO;
             let (self_p, carry) = self.add_no_reduce(&P256);
-            for i in 0us..(LIMBS - 1) {
+            for i in 0..(LIMBS - 1) {
                 half_odd.v[i] = (self_p.v[i] >> 1) | ((self_p.v[i + 1] & 1) << 31);
             }
             half_odd.v[LIMBS - 1] = (self_p.v[LIMBS - 1] >> 1) | (carry << 31);
@@ -571,9 +571,9 @@ pub mod int256 {
         // big-endian.
         pub fn to_bytes(&self) -> Vec<u8> {
             let mut b = [0u8; 256 / 8];
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 let vi = self.v[LIMBS - 1 - i];
-                for j in (0us..4) {
+                for j in (0..4) {
                     b[i * 4 + j] = (vi >> ((3 - j) * 8)) as u8;
                 }
             }
@@ -588,9 +588,9 @@ pub mod int256 {
             }
 
             let mut x = ZERO;
-            for i in (0us..LIMBS) {
+            for i in (0..LIMBS) {
                 let mut vi = 0u32;
-                for j in (0us..4) {
+                for j in (0..4) {
                     vi |= (b[i * 4 + j] as u32) << ((3 - j) * 8);
                 }
                 x.v[LIMBS - 1 - i] = vi;

--- a/src/crypto/p256.rs
+++ b/src/crypto/p256.rs
@@ -262,8 +262,8 @@ impl NPoint256 {
         // 0x04 || self.x (big endian) || self.y (big endian)
         let mut b = Vec::with_capacity(1 + (256 / 8) * 2);
         b.push(0x04); // uncompressed
-        b.push_all(&self.x.to_bytes()[]);
-        b.push_all(&self.y.to_bytes()[]);
+        b.push_all(&self.x.to_bytes());
+        b.push_all(&self.y.to_bytes());
         b
     }
 }
@@ -606,13 +606,13 @@ pub mod int256 {
 
         impl PartialEq for Int256 {
             fn eq(&self, b: &Int256) -> bool {
-                self.v[] == b.v[]
+                self.v == b.v
             }
         }
 
         impl ::std::fmt::Debug for Int256 {
             fn fmt(&self, a: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                self.v[].fmt(a)
+                self.v.fmt(a)
             }
         }
 
@@ -766,7 +766,7 @@ pub mod int256 {
         fn test_from_bytes() {
             for a in VALUES_256.iter() {
                 let b = a.to_bytes();
-                let aa = Int256::from_bytes(&b[]).expect("to_bytes failed");
+                let aa = Int256::from_bytes(&b).expect("to_bytes failed");
                 assert_eq!(*a, aa);
             }
         }

--- a/src/crypto/poly1305.rs
+++ b/src/crypto/poly1305.rs
@@ -1,5 +1,7 @@
 // http://cr.yp.to/mac/poly1305-20050329.pdf
 
+use crypto::wrapping::*;
+
 macro_rules! choose_impl {
     ($s: ident, $t:ty, $($a:expr)+) => (
         impl $s {
@@ -229,10 +231,10 @@ pub fn authenticate(msg: &[u8], r: &[u8; 16], aes: &[u8; 16]) -> [u8; 16] {
     let h = {
         macro_rules! b {
             ($i:expr, $n:expr) => (
-                (h.v[$i] >> $n) as u8
+                Wrapping(h.v[$i] >> $n).to_w8().0
             );
             ($i:expr, $n:expr, $m:expr) => (
-                ((h.v[$i] >> $n) | (h.v[$i+1] & ((1 << $m) - 1)) << (8 - $m)) as u8
+                Wrapping((h.v[$i] >> $n) | (h.v[$i+1] & ((1 << $m) - 1)) << (8 - $m)).to_w8().0
             );
         }
 
@@ -294,10 +296,10 @@ pub fn authenticate(msg: &[u8], r: &[u8; 16], aes: &[u8; 16]) -> [u8; 16] {
 
         macro_rules! to_u8 {
             ($a:expr, $r:expr, $i:expr) => ({
-                $a[$i] = $r as u8;
-                $a[$i+1] = ($r >> 8) as u8;
-                $a[$i+2] = ($r >> 16) as u8;
-                $a[$i+3] = ($r >> 24) as u8;
+                $a[$i] = Wrapping($r).to_w8().0;
+                $a[$i+1] = Wrapping($r >> 8).to_w8().0;
+                $a[$i+2] = Wrapping($r >> 16).to_w8().0;
+                $a[$i+3] = Wrapping($r >> 24).to_w8().0;
             })
         }
 

--- a/src/crypto/poly1305.rs
+++ b/src/crypto/poly1305.rs
@@ -339,13 +339,13 @@ mod test {
 
     impl PartialEq for Int1305 {
         fn eq(&self, b: &Int1305) -> bool {
-            self.normalize().v[] == b.normalize().v[]
+            self.normalize().v == b.normalize().v
         }
     }
 
     impl ::std::fmt::Debug for Int1305 {
         fn fmt(&self, a: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-            (self.v[]).fmt(a)
+            (self.v).fmt(a)
         }
     }
 
@@ -370,13 +370,13 @@ mod test {
     #[test]
     fn test_normalize() {
         let p = Int1305 { v: [0x3fffffb, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff] };
-        assert_eq!(&p.normalize().v[], &super::ZERO.v[]);
+        assert_eq!(&p.normalize().v, &super::ZERO.v);
 
         let large = Int1305 { v: [0, 10, 5, 10, 1 << 26] };
         let small = Int1305 { v: [5, 10, 5, 10, 0] };
 
-        assert_eq!(&large.normalize().v[], &small.v[]);
-        assert_eq!(&small.normalize().v[], &small.v[]);
+        assert_eq!(&large.normalize().v, &small.v);
+        assert_eq!(&small.normalize().v, &small.v);
 
         for a in COEFFS.iter() {
             assert_eq!(a.normalize(), *a);
@@ -451,7 +451,7 @@ mod test {
 
         for &(msg, ref r, ref aes, ref expected) in VALUES.iter() {
             let output = super::authenticate(msg, r, aes);
-            assert_eq!(&output[], &expected[]);
+            assert_eq!(&output[..], &expected[..]);
         }
     }
 }

--- a/src/crypto/sha2.rs
+++ b/src/crypto/sha2.rs
@@ -45,7 +45,7 @@ pub fn sha256(msg: &[u8]) -> [u8; 32] {
     }
 
     let bitlen = (len as u64) * 8; // FIXME: is overflow intended in spec?
-    for i in (0us..8us).rev() {
+    for i in (0..8).rev() {
         let b = (bitlen >> (8 * i)) as u8;
         msg.push(b);
     }
@@ -59,7 +59,7 @@ pub fn sha256(msg: &[u8]) -> [u8; 32] {
     for i in (0..nblk) {
         let w = {
             let mut w = [0u32; 64];
-            for j in 0..16us {
+            for j in 0..16 {
                 let b0 = msg[i * 64 + j * 4 + 0] as u32;
                 let b1 = msg[i * 64 + j * 4 + 1] as u32;
                 let b2 = msg[i * 64 + j * 4 + 2] as u32;
@@ -67,7 +67,7 @@ pub fn sha256(msg: &[u8]) -> [u8; 32] {
                 w[j] = (b0 << 8 * 3) | (b1 << 8 * 2) | (b2 << 8 * 1) | b3;
             }
 
-            for j in 16..64us {
+            for j in 16..64 {
                 let wj15 = w[j - 15];
                 let sig0 = rot(wj15, 7) ^ rot(wj15, 18) ^ (wj15 >> 3);
 
@@ -88,7 +88,7 @@ pub fn sha256(msg: &[u8]) -> [u8; 32] {
         let mut g: u32 = val[6];
         let mut h: u32 = val[7];
 
-        for j in 0..64us {
+        for j in 0..64 {
             let ch = (e & f) ^ ((!e) & g);
             let maj = (a & b) ^ (a & c) ^ (b & c);
 
@@ -120,7 +120,7 @@ pub fn sha256(msg: &[u8]) -> [u8; 32] {
     }
 
     let mut ret = [0u8; 32];
-    for i in 0..8us {
+    for i in 0..8 {
         ret[i * 4 + 0] = (val[i] >> 8 * 3) as u8;
         ret[i * 4 + 1] = (val[i] >> 8 * 2) as u8;
         ret[i * 4 + 2] = (val[i] >> 8 * 1) as u8;

--- a/src/crypto/sha2.rs
+++ b/src/crypto/sha2.rs
@@ -149,7 +149,7 @@ mod test {
 
         for &(input, expected) in ANSWERS.iter() {
             let computed = sha256(input);
-            assert_eq!(expected, &computed[]);
+            assert_eq!(expected, &computed);
         }
     }
 }

--- a/src/crypto/wrapping.rs
+++ b/src/crypto/wrapping.rs
@@ -1,0 +1,67 @@
+#![allow(non_camel_case_types)]
+
+// NOTE: since there is no const fn (yet), you can't use `w32(100)` function
+// for consts and statics. (workaround: use `Wrapping(100)`.)
+
+pub use std::num::wrapping::{Wrapping, WrappingOps};
+
+pub trait ToWrapping {
+    fn to_w64(self) -> w64;
+    fn to_w32(self) -> w32;
+    fn to_w16(self) -> w16;
+    fn to_w8(self) -> w8;
+}
+
+macro_rules! to_wrapping_impl_fn {
+    ($name:ident, $ut:ty, $wt:ty, $size:expr) => (
+        #[inline(always)]
+        fn $name(self) -> $wt {
+            // NOTE: `WrappingOps::wrapping_as_u64()` can be used when implemented
+            let val: u64 = self.0 as u64;
+            let val: u64 = val & ((1 << $size) - 1);
+            let val: $ut = val as $ut;
+            Wrapping(val)
+        }
+    )
+}
+
+macro_rules! wrapping_type {
+    ($wt:ident, $ut:ident) => (
+        pub type $wt = Wrapping<$ut>;
+
+        #[inline(always)]
+        pub fn $wt(val: $ut) -> $wt {
+            Wrapping(val)
+        }
+
+        impl ToWrapping for Wrapping<$ut> {
+            #[inline(always)]
+            fn to_w64(self) -> w64 {
+                Wrapping(self.0 as u64)
+            }
+
+            to_wrapping_impl_fn!(to_w8, u8, w8, 8);
+            to_wrapping_impl_fn!(to_w16, u16, w16, 16);
+            to_wrapping_impl_fn!(to_w32, u32, w32, 32);
+        }
+
+    )
+}
+
+wrapping_type!(w64, u64);
+wrapping_type!(w32, u32);
+wrapping_type!(w16, u16);
+wrapping_type!(w8, u8);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_to_wrapping() {
+        const V: w64 = Wrapping(0x12345678_87654321);
+        assert_eq!(V.to_w32().0, 0x87654321);
+        assert_eq!(V.to_w16().0, 0x4321);
+        assert_eq!(V.to_w8().0, 0x21);
+    }
+}

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -118,9 +118,9 @@ macro_rules! tls_handshake(
                             try!(writer.write_u8(tt_to_expr!($num)));
 
                             let len = body.tls_size();
-                            try!(writer.write_u8((len >> 16) as u8));
-                            try!(writer.write_u8((len >> 8) as u8));
-                            try!(writer.write_u8(len as u8));
+                            try!(writer.write_u8(((len >> 16) & 0xff) as u8));
+                            try!(writer.write_u8(((len >> 8) & 0xff) as u8));
+                            try!(writer.write_u8((len & 0xff) as u8));
 
                             try!(body.tls_write(writer));
                         }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,5 +1,6 @@
-use std::old_io::MemReader;
+use std::io::prelude::*;
 
+use util::{ReadExt, WriteExt};
 use tls::TLS_VERSION;
 use tls_result::TlsResult;
 use tls_result::TlsErrorKind::{InternalError, UnexpectedMessage};
@@ -111,7 +112,7 @@ macro_rules! tls_handshake(
         }
 
         impl TlsItem for Handshake {
-            fn tls_write<W: Writer>(&self, writer: &mut W) -> TlsResult<()> {
+            fn tls_write<W: WriteExt>(&self, writer: &mut W) -> TlsResult<()> {
                 match *self {
                     $(
                         Handshake::$name(ref body) => {
@@ -130,7 +131,7 @@ macro_rules! tls_handshake(
                 Ok(())
             }
 
-            fn tls_read<R: Reader>(reader: &mut R) -> TlsResult<Handshake> {
+            fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<Handshake> {
                 let ty = try!(reader.read_u8());
 
                 // HandshakeBuffer already checked validity of length
@@ -270,8 +271,8 @@ impl HandshakeBuffer {
         };
         self.buf = remaining;
 
-        let mut reader = MemReader::new(message);
-        let message: Handshake = try!(TlsItem::tls_read(&mut reader));
+        let mut reader = &mut &message[..];
+        let message: Handshake = try!(TlsItem::tls_read(reader));
         let ret = Ok(Some(message));
 
         ret
@@ -340,7 +341,7 @@ impl Handshake {
 
 #[cfg(test)]
 mod test {
-    use std::old_io::MemReader;
+    use std::io::Cursor;
     use tls_item::TlsItem;
     use cipher::CipherSuite;
 
@@ -396,7 +397,7 @@ mod test {
         let mut packet = Vec::new();
         client_hello_msg.tls_write(&mut packet).unwrap();
 
-        let mut reader = MemReader::new(packet.clone());
+        let mut reader = Cursor::new(&packet[..]);
         let client_hello_msg_2: Handshake = TlsItem::tls_read(&mut reader).unwrap();
 
         let mut packet_2 = Vec::new();

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -240,7 +240,7 @@ impl HandshakeBuffer {
     }
 
     pub fn add_record(&mut self, fragment: Vec<u8>) {
-        self.buf.push_all(&fragment[]);
+        self.buf.push_all(&fragment);
     }
 
     // if message is arrived but has unknown type, the message is discarded and returns error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,7 @@
 
 #![allow(missing_copy_implementations)]
 
-#![feature(slicing_syntax)]
-#![feature(core)]
-#![feature(io)]
-#![feature(collections)]
+#![feature(io, core, collections, net)]
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,7 @@ pub mod macros;
 pub mod util;
 
 // basic crypto primitives
-pub mod crypto {
-    pub mod sha2;
-    pub mod p256;
-    pub mod poly1305;
-    pub mod chacha20;
-}
+pub mod crypto;
 
 pub mod tls_result;
 #[macro_use]

--- a/src/record.rs
+++ b/src/record.rs
@@ -119,7 +119,7 @@ impl<W: Writer> RecordWriter<W> {
                 ad.push(frag_len as u8);
 
                 let encrypted_fragment = encryptor.encrypt(&seq_num,
-                                                           &*record.fragment,
+                                                           &record.fragment,
                                                            &ad);
                 EncryptedRecord::new(record.content_type,
                                      record.ver_major,
@@ -136,7 +136,7 @@ impl<W: Writer> RecordWriter<W> {
         try!(self.writer.write_u8(minor));
 
         try!(self.writer.write_be_u16(fragment_len));
-        try!(self.writer.write_all(&*enc_record.fragment));
+        try!(self.writer.write_all(&enc_record.fragment));
 
         self.write_count += 1;
 
@@ -258,7 +258,7 @@ impl<R: Reader> RecordReader<R> {
 
                 // TODO: "seq_num as nonce" is chacha20poly1305-specific
                 let data = try!(decryptor.decrypt(&seq_num,
-                                                  &*enc_record.fragment,
+                                                  &enc_record.fragment,
                                                   &ad));
 
                 Record::new(enc_record.content_type,

--- a/src/record.rs
+++ b/src/record.rs
@@ -110,7 +110,7 @@ impl<W: Writer> RecordWriter<W> {
                 let seq_num = u64_be_array(self.write_count);
 
                 let mut ad = Vec::new();
-                ad.push_all(&seq_num[]);
+                ad.push_all(&seq_num);
                 ad.push(record.content_type as u8);
                 ad.push(record.ver_major);
                 ad.push(record.ver_minor);
@@ -118,9 +118,9 @@ impl<W: Writer> RecordWriter<W> {
                 ad.push((frag_len >> 8) as u8);
                 ad.push(frag_len as u8);
 
-                let encrypted_fragment = encryptor.encrypt(&seq_num[],
+                let encrypted_fragment = encryptor.encrypt(&seq_num,
                                                            &*record.fragment,
-                                                           &ad[]);
+                                                           &ad);
                 EncryptedRecord::new(record.content_type,
                                      record.ver_major,
                                      record.ver_minor,
@@ -158,13 +158,13 @@ impl<W: Writer> RecordWriter<W> {
     pub fn write_handshake(&mut self, handshake: &Handshake) -> TlsResult<()> {
         let mut data = Vec::new();
         try!(handshake.tls_write(&mut data));
-        self.write_data(HandshakeTy, &data[])
+        self.write_data(HandshakeTy, &data)
     }
 
     pub fn write_alert(&mut self, alert: &Alert) -> TlsResult<()> {
         let mut data = Vec::new();
         try!(alert.tls_write(&mut data));
-        self.write_data(AlertTy, &data[])
+        self.write_data(AlertTy, &data)
     }
 
     pub fn write_change_cipher_spec(&mut self) -> TlsResult<()> {
@@ -242,7 +242,7 @@ impl<R: Reader> RecordReader<R> {
                 let seq_num = u64_be_array(self.read_count);
 
                 let mut ad = Vec::new();
-                ad.push_all(&seq_num[]);
+                ad.push_all(&seq_num);
                 ad.push(enc_record.content_type as u8); // TLSCompressed.type
                 ad.push(enc_record.ver_major);
                 ad.push(enc_record.ver_minor);
@@ -257,9 +257,9 @@ impl<R: Reader> RecordReader<R> {
                 ad.push(frag_len as u8);
 
                 // TODO: "seq_num as nonce" is chacha20poly1305-specific
-                let data = try!(decryptor.decrypt(&seq_num[],
+                let data = try!(decryptor.decrypt(&seq_num,
                                                   &*enc_record.fragment,
-                                                  &ad[]));
+                                                  &ad));
 
                 Record::new(enc_record.content_type,
                             enc_record.ver_major,

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,4 @@
+use std::io::prelude::*;
 use std::num::FromPrimitive;
 
 use tls_result::TlsResult;
@@ -5,6 +6,7 @@ use tls_result::TlsErrorKind::{UnexpectedMessage, RecordOverflow, BadRecordMac, 
 use alert::Alert;
 use handshake::{Handshake, HandshakeBuffer};
 use util::u64_be_array;
+use util::{ReadExt, WriteExt};
 use cipher::{Encryptor, Decryptor};
 use tls_item::TlsItem;
 use tls::TLS_VERSION;
@@ -79,14 +81,14 @@ impl EncryptedRecord {
     }
 }
 
-pub struct RecordWriter<W: Writer> {
+pub struct RecordWriter<W: Write> {
     writer: W,
     // if encryptor is None, handshake is not done yet.
     encryptor: Option<Box<Encryptor + 'static>>,
     write_count: u64,
 }
 
-impl<W: Writer> RecordWriter<W> {
+impl<W: Write> RecordWriter<W> {
     pub fn new(writer: W) -> RecordWriter<W> {
         RecordWriter {
             writer: writer,
@@ -186,7 +188,7 @@ pub enum Message {
     ApplicationDataMessage(Vec<u8>),
 }
 
-pub struct RecordReader<R: Reader> {
+pub struct RecordReader<R: ReadExt> {
     reader: R,
     // if decryptor is none, handshake is not done yet.
     decryptor: Option<Box<Decryptor + 'static>>,
@@ -194,7 +196,7 @@ pub struct RecordReader<R: Reader> {
     handshake_buffer: HandshakeBuffer,
 }
 
-impl<R: Reader> RecordReader<R> {
+impl<R: ReadExt> RecordReader<R> {
     pub fn new(reader: R) -> RecordReader<R> {
         RecordReader {
             reader: reader,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,5 +1,6 @@
 // 7.4.1.4.1 Signature algorithm
 
+use util::{ReadExt, WriteExt};
 use tls_item::TlsItem;
 
 tls_enum!(u8, enum HashAlgorithm {

--- a/src/test.rs
+++ b/src/test.rs
@@ -71,7 +71,7 @@ fn test_application_message() {
     {
         let mut reader = MemReader::new(Vec::new());
         let mut tls = null_tls(reader.by_ref(), writer.by_ref());
-        tls.writer.write_application_data(&app_data[]).unwrap();
+        tls.writer.write_application_data(&app_data).unwrap();
     }
 
     let data = writer;
@@ -83,7 +83,7 @@ fn test_application_message() {
         let msg = tls.reader.read_message().unwrap();
         match msg {
             ApplicationDataMessage(msg) => {
-                assert_eq!(msg, &[1u8; RECORD_MAX_LEN][]);
+                assert_eq!(msg, &[1u8; RECORD_MAX_LEN][..]);
             },
             _ => panic!(),
         }
@@ -91,7 +91,7 @@ fn test_application_message() {
         let msg = tls.reader.read_message().unwrap();
         match msg {
             ApplicationDataMessage(msg) => {
-                assert_eq!(msg, &[1u8; 200][]);
+                assert_eq!(msg, &[1u8; 200][..]);
             },
             _ => panic!(),
         }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,4 @@
+use std::io::prelude::*;
 use rand::OsRng;
 
 use tls_result::{TlsResult, TlsError, TlsErrorKind};
@@ -6,13 +7,13 @@ use alert::{self, Alert};
 
 pub static TLS_VERSION: (u8, u8) = (3, 3);
 
-pub struct Tls<R: Reader, W: Writer> {
+pub struct Tls<R: Read, W: Write> {
     pub writer: RecordWriter<W>,
     pub reader: RecordReader<R>,
     pub rng: OsRng,
 }
 
-impl<R: Reader, W: Writer> Tls<R, W> {
+impl<R: Read, W: Write> Tls<R, W> {
     pub fn new(reader: R, writer: W, rng: OsRng) -> Tls<R, W> {
         let writer = RecordWriter::new(writer);
         let reader = RecordReader::new(reader);

--- a/src/tls_item.rs
+++ b/src/tls_item.rs
@@ -208,7 +208,7 @@ macro_rules! tls_array {
 
         impl TlsItem for $name {
             fn tls_write<W: Writer>(&self, writer: &mut W) -> $crate::tls_result::TlsResult<()> {
-                try!(writer.write(&self.0[]));
+                try!(writer.write(&self.0));
                 Ok(())
             }
 
@@ -225,7 +225,7 @@ macro_rules! tls_array {
         impl ::std::ops::Deref for $name {
             type Target = [u8];
             fn deref<'a>(&'a self) -> &'a [u8] {
-                &self.0[]
+                &self.0
             }
         }
     )
@@ -355,7 +355,7 @@ macro_rules! tls_vec {
         impl ::std::ops::Deref for $name {
             type Target = [$item_ty];
             fn deref<'a>(&'a self) -> &'a [$item_ty] {
-                &self.0[]
+                &self.0
             }
         }
     )
@@ -422,7 +422,7 @@ pub struct ObscureData(Vec<u8>);
 
 impl TlsItem for ObscureData {
     fn tls_write<W: Writer>(&self, writer: &mut W) -> TlsResult<()> {
-        try!(writer.write_all(&self.0[]));
+        try!(writer.write_all(&self.0));
         Ok(())
     }
 
@@ -448,6 +448,6 @@ impl ObscureData {
 impl ::std::ops::Deref for ObscureData {
     type Target = [u8];
     fn deref<'a>(&'a self) -> &'a [u8] {
-        &self.0[]
+        &self.0
     }
 }

--- a/src/tls_result.rs
+++ b/src/tls_result.rs
@@ -1,5 +1,5 @@
 use std::error::{Error, FromError};
-use std::old_io::IoError;
+use std::io;
 use std::fmt;
 
 #[derive(Copy, PartialEq, Debug)]
@@ -54,8 +54,8 @@ impl Error for TlsError {
     }
 }
 
-impl FromError<IoError> for TlsError {
-    fn from_error(err: IoError) -> TlsError {
+impl FromError<io::Error> for TlsError {
+    fn from_error(err: io::Error) -> TlsError {
         TlsError {
             kind: TlsErrorKind::IoFailure,
             desc: format!("io error: {}", err),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use std::mem;
 use std::num::Int;
+use std::io::{self, Read, Write};
 
 /// constant-time compare function.
 /// `a` and `b` may be SECRET, but the length is known.
@@ -25,3 +26,127 @@ pub fn u64_be_array(x: u64) -> [u8; 8] {
 pub fn u64_le_array(x: u64) -> [u8; 8] {
     unsafe { mem::transmute(x.to_le()) }
 }
+
+// native endians.
+macro_rules! read_write_prim {
+    ($read_name:ident, $write_name:ident, $t:ty, $len:expr) => (
+        #[inline(always)]
+        fn $read_name<R: ?Sized + ReadExt>(mut reader: &mut R) -> io::Result<$t> {
+            let mut buf = [0u8; $len];
+            try!(reader.fill_exact(&mut buf));
+            let value: $t = unsafe { mem::transmute(buf) };
+            Ok(value)
+        }
+        #[inline(always)]
+        fn $write_name<R: ?Sized + Write>(mut writer: &mut R, value: $t) -> io::Result<()> {
+            let buf: [u8; $len] = unsafe { mem::transmute(value) };
+            try!(writer.write_all(&buf));
+            Ok(())
+        }
+    )
+}
+
+read_write_prim!(read_u8, write_u8, u8, 1);
+read_write_prim!(read_u16, write_u16, u16, 2);
+read_write_prim!(read_u32, write_u32, u32, 4);
+read_write_prim!(read_u64, write_u64, u64, 8);
+
+pub trait ReadExt: Read {
+    /// Fill buf completely or return `Err`.
+    /// NOTE: the default implementation returns `Err(io::ErrorKind::Other)` if EOF is found.
+    /// this may be not desired if the source is non-blocking.
+    #[inline(always)]
+    fn fill_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        let len = buf.len();
+        let mut pos = 0;
+        while pos < len {
+            let num_bytes = try!(self.read(&mut buf[pos..]));
+            if num_bytes == 0 {
+                return Err(io::Error::new(io::ErrorKind::Other, "EOF during `fill_exact`", None));
+            }
+            pos += num_bytes;
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn read_exact(&mut self, len: usize) -> io::Result<Vec<u8>> {
+        // FIXME this can be more efficient using unsafe methods
+        let mut vec = vec![0u8; len];
+        try!(self.fill_exact(&mut vec));
+        Ok(vec)
+    }
+
+    #[inline(always)]
+    fn read_u8(&mut self) -> io::Result<u8> {
+        read_u8(self)
+    }
+    #[inline(always)]
+    fn read_be_u16(&mut self) -> io::Result<u16> {
+        let value: u16 = try!(read_u16(self));
+        Ok(value.to_be())
+    }
+    #[inline(always)]
+    fn read_le_u16(&mut self) -> io::Result<u16> {
+        let value: u16 = try!(read_u16(self));
+        Ok(value.to_le())
+    }
+    #[inline(always)]
+    fn read_be_u32(&mut self) -> io::Result<u32> {
+        let value: u32 = try!(read_u32(self));
+        Ok(value.to_be())
+    }
+    #[inline(always)]
+    fn read_le_u32(&mut self) -> io::Result<u32> {
+        let value: u32 = try!(read_u32(self));
+        Ok(value.to_le())
+    }
+    #[inline(always)]
+    fn read_be_u64(&mut self) -> io::Result<u64> {
+        let value: u64 = try!(read_u64(self));
+        Ok(value.to_be())
+    }
+    #[inline(always)]
+    fn read_le_u64(&mut self) -> io::Result<u64> {
+        let value: u64 = try!(read_u64(self));
+        Ok(value.to_le())
+    }
+}
+
+impl<R: Read> ReadExt for R {}
+
+pub trait WriteExt: Write {
+    #[inline(always)]
+    fn write_u8(&mut self, value: u8) -> io::Result<()> {
+        write_u8(self, value)
+    }
+
+    #[inline(always)]
+    fn write_be_u16(&mut self, value: u16) -> io::Result<()> {
+        write_u16(self, value.to_be())
+    }
+    #[inline(always)]
+    fn write_le_u16(&mut self, value: u16) -> io::Result<()> {
+        write_u16(self, value.to_le())
+    }
+
+    #[inline(always)]
+    fn write_be_u32(&mut self, value: u32) -> io::Result<()> {
+        write_u32(self, value.to_be())
+    }
+    #[inline(always)]
+    fn write_le_u32(&mut self, value: u32) -> io::Result<()> {
+        write_u32(self, value.to_le())
+    }
+
+    #[inline(always)]
+    fn write_be_u64(&mut self, value: u64) -> io::Result<()> {
+        write_u64(self, value.to_be())
+    }
+    #[inline(always)]
+    fn write_le_u64(&mut self, value: u64) -> io::Result<()> {
+        write_u64(self, value.to_le())
+    }
+}
+
+impl<W: Write> WriteExt for W {}


### PR DESCRIPTION
This patchset fixes:

- obsolete syntax issues
- crypto algorithms due to overflow semantic changes
- std::io changes

rustc version: nightly 30e1f9a1c 2015-03-14