### PR TITLE
Fix E0034 ambiguity errors with Universal Funtion Call syntax

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -115,7 +115,7 @@ macro_rules! tls_hello_extension {
                         }
                     )+
                     _ => {
-                        let body: Vec<u8> = try!(reader.read_exact(extension_data_size as usize));
+                        let body: Vec<u8> = try!(ReadExt::read_exact(reader, extension_data_size as usize));
                         Ok($enum_name::Unknown(extension_type, body))
                     }
                 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -235,7 +235,7 @@ impl<R: ReadExt> TlsReader<R> {
             len
         };
 
-        let fragment = try!(self.reader.read_exact(len as usize));
+        let fragment = try!(ReadExt::read_exact(&mut self.reader, len as usize));
 
         let record = match self.decryptor {
             None => {

--- a/src/tls_item.rs
+++ b/src/tls_item.rs
@@ -164,7 +164,7 @@ macro_rules! tls_array {
             }
 
             fn tls_read<R: ReadExt>(reader: &mut R) -> $crate::tls_result::TlsResult<$name> {
-                let data = try!(reader.read_exact($n));
+                let data = try!(ReadExt::read_exact(reader, $n));
                 Ok($name(data))
             }
 


### PR DESCRIPTION
It won't compile in Rust 1.5 without the UFC

(Actually it still won't compile in Rust 1.5 because of a different error. The error is the use of deprecated `std::slice::bytes::copy_memory` in `src/client.rs:4`. See #15)