### PR TITLE
Add copy_memory replacement function, because it's deprecated

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::io::prelude::*;
 use std::net::TcpStream;
-use std::slice::bytes::copy_memory;
 use std::cmp;
 use rand::{Rng, OsRng};
 
@@ -298,6 +297,11 @@ impl<R: Read, W: Write> Write for TlsClient<R, W> {
             }
         }
     }
+}
+
+// A replacement for the deprecated std::slice::bytes::copy_memory
+fn copy_memory(from: &[u8], mut to: &mut [u8]) -> usize {
+    to.write(from).unwrap()
 }
 
 impl<R: Read, W: Write> Read for TlsClient<R, W> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![crate_type = "lib"]
 #![crate_name = "suruga"]
 
-#![feature(slice_bytes)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
`copy_memory` is already deprecated, as per rust-lang/rust#27740 and removed from Rust 1.5

After applying #14 and this PR, suruga can be built and passes `cargo test` on Rust 1.5