### PR TITLE
Use Sized trait for Self

### DIFF
--- a/src/tls_item.rs
+++ b/src/tls_item.rs
@@ -18,7 +18,7 @@ pub trait TlsItem {
     /// Write an item into TLS stream.
     fn tls_write<W: WriteExt>(&self, writer: &mut W) -> TlsResult<()>;
     /// Read an item from TLS stream.
-    fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<Self>;
+    fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<Self> where Self: Sized;
     /// Returns the length of serialized bytes.
     fn tls_size(&self) -> u64;
 }


### PR DESCRIPTION
Use `Sized` trait for `Self`, to remove this kind of warning:

```
λ cargo build
   Compiling suruga v0.1.0
src\tls_item.rs:21:5: 21:64 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src\tls_item.rs:21     fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src\tls_item.rs:21:5: 21:64 help: run `rustc --explain E0277` to see a detailed explanation
src\tls_item.rs:21:5: 21:64 note: `Self` does not have a constant size known at compile-time
src\tls_item.rs:21:5: 21:64 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src\tls_item.rs:21     fn tls_read<R: ReadExt>(reader: &mut R) -> TlsResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src\tls_item.rs:21:5: 21:64 note: required by `core::result::Result`

```

Because it would be a hard error in the next Rust version.
